### PR TITLE
Remove stale sockets in availableSockets

### DIFF
--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -80,7 +80,7 @@ class Client extends EventEmitter {
     };
 
     const clientReq = http.request(opt, (clientRes: IncomingMessage) => {
-      this.debug('< %s', req.url);
+      this.debug(`< ${req.url} [${clientRes.statusCode} ${clientRes.statusMessage}]`);
       // write response code and headers
       res.writeHead(clientRes.statusCode!, clientRes.headers);
 

--- a/lib/ClientManager.ts
+++ b/lib/ClientManager.ts
@@ -54,15 +54,19 @@ class ClientManager {
     // can't ask for id already is use
     if (clients.has(id)) {
       logger.info(
-        `Client with id "${id}" already exists. Removing old client and creating new one.`
+        `Client with id "${id}" already exists. Removing old client and creating new one.`,
       );
       this.removeClient(id);
     }
 
+    // This is how many sockets the client will try to keep up
     const maxSockets = this.opt.max_tcp_sockets ?? 10;
     const agent = new TunnelAgent({
       clientId: id,
-      maxTcpSockets: 10,
+      maxClientSockets: maxSockets,
+      // This is how many sockets the server can accept before throwing an
+      // error. Set it to 2x in case the client is slow to close sockets.
+      maxTcpSockets: maxSockets * 3,
     });
 
     const client = new Client({

--- a/lib/TunnelAgent.ts
+++ b/lib/TunnelAgent.ts
@@ -3,14 +3,13 @@ import { Agent } from 'http';
 import net, { Socket } from 'net';
 import { endOrDestroy } from './utils';
 
-const DEFAULT_MAX_SOCKETS = 10;
-
 // Implements an http.Agent interface to a pool of tunnel sockets
 // A tunnel socket is a connection _from_ a client that will
 // service http requests. This agent is usable wherever one can use an http.Agent
 interface TunnelAgentOptions {
   clientId: string;
-  maxTcpSockets?: number;
+  maxClientSockets: number;
+  maxTcpSockets: number;
 }
 
 interface ListenInfo {
@@ -27,16 +26,15 @@ class TunnelAgent extends Agent {
   private debug: Debug.Debugger;
   private connectedSockets: number;
   private maxTcpSockets: number;
+  private maxClientSockets: number;
   private server: net.Server;
   private started: boolean;
   private closed: boolean;
 
-  constructor(options: TunnelAgentOptions = { clientId: '' }) {
+  constructor(options: TunnelAgentOptions) {
     super({
       keepAlive: true,
-      // only allow keepalive to hold on to one socket
-      // this prevents it from holding on to all the sockets so they can be used for upgrades
-      maxFreeSockets: 1,
+      maxFreeSockets: options.maxClientSockets,
     });
 
     // sockets we can hand out via createConnection
@@ -50,7 +48,8 @@ class TunnelAgent extends Agent {
 
     // track maximum allowed sockets
     this.connectedSockets = 0;
-    this.maxTcpSockets = options.maxTcpSockets || DEFAULT_MAX_SOCKETS;
+    this.maxTcpSockets = options.maxTcpSockets;
+    this.maxClientSockets = options.maxClientSockets;
 
     // new tcp server to service requests for this client
     this.server = net.createServer();
@@ -107,6 +106,10 @@ class TunnelAgent extends Agent {
   }
 
   private _onConnection(socket: Socket) {
+    socket.setKeepAlive(true, 1000);
+    socket.setTimeout(0);
+    socket.resume();
+
     // no more socket connections allowed
     if (this.connectedSockets >= this.maxTcpSockets) {
       this.debug('no more sockets allowed');
@@ -114,16 +117,26 @@ class TunnelAgent extends Agent {
       return false;
     }
 
+    // When the client side sends FIN the socket, we must also send FIN to
+    // follow close the socket. This will trigger the 'close' event.
+    socket.once('end', () => {
+      this.debug(`socket ended ${socket.localPort}:${socket.remotePort}`);
+      socket.end();
+    });
+
     socket.once('close', hadError => {
-      this.debug('closed socket (error: %s)', hadError);
       this.connectedSockets -= 1;
+
       // remove the socket from available list
       const idx = this.availableSockets.indexOf(socket);
       if (idx >= 0) {
         this.availableSockets.splice(idx, 1);
       }
 
-      this.debug('connected sockets: %s', this.connectedSockets);
+      this.debug(
+        `closed socket (error: ${hadError}). ${socket.localPort}:${socket.remotePort} Socket counts: ${this.availableSockets.length} / ${this.connectedSockets}`,
+      );
+
       if (this.connectedSockets <= 0) {
         this.debug('all sockets disconnected');
         this.emit('offline');
@@ -132,6 +145,7 @@ class TunnelAgent extends Agent {
 
     // close will be emitted after this
     socket.once('error', err => {
+      this.debug('socket error %s', err);
       // we do not log these errors, sessions can drop from clients for many reasons
       // these are not actionable errors for our server
       endOrDestroy(socket);
@@ -142,8 +156,6 @@ class TunnelAgent extends Agent {
     }
 
     this.connectedSockets += 1;
-    const { address, port } = socket.address() as net.AddressInfo;
-    this.debug('new connection from: %s:%s', address, port);
 
     // if there are queued callbacks, give this socket now and don't queue into available
     const fn = this.waitingCreateConn.shift();
@@ -152,11 +164,15 @@ class TunnelAgent extends Agent {
       setTimeout(() => {
         fn(null, socket);
       }, 0);
-      return;
+    } else {
+      // make socket available for those waiting on sockets
+      this.availableSockets.push(socket);
     }
 
-    // make socket available for those waiting on sockets
-    this.availableSockets.push(socket);
+    const { address, port } = socket.address() as net.AddressInfo;
+    this.debug(
+      `New connection from: ${address}:${port}. ${socket.localPort}:${socket.remotePort} Socket counts: ${this.availableSockets.length} / ${this.connectedSockets}`,
+    );
   }
 
   // fetch a socket from the available socket pool for the agent
@@ -171,7 +187,7 @@ class TunnelAgent extends Agent {
     this.debug('create connection');
 
     // socket is a tcp connection back to the user hosting the site
-    const sock = this.availableSockets.shift();
+    const sock = this.availableSockets.pop();
 
     // no available sockets
     // wait until we have one
@@ -182,7 +198,10 @@ class TunnelAgent extends Agent {
       return;
     }
 
-    this.debug('socket given');
+    this.debug(
+      `Socket given. Socket counts: ${this.availableSockets.length} / ${this.connectedSockets}`,
+    );
+
     cb(null, sock);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/tldjs": "2.3.4",
         "mocha": "5.1.1",
         "node-dev": "3.1.3",
+        "prettier": "3.5.3",
         "supertest": "3.1.0",
         "tsx": "4.19.3",
         "typescript": "5.7.3",
@@ -2255,6 +2256,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/tldjs": "2.3.4",
     "mocha": "5.1.1",
     "node-dev": "3.1.3",
+    "prettier": "3.5.3",
     "supertest": "3.1.0",
     "tsx": "4.19.3",
     "typescript": "5.7.3",
@@ -37,8 +38,7 @@
   },
   "scripts": {
     "test": "mocha --check-leaks --require esm './**/*.test.js'",
-    "start": "tsc --noEmit && tsx ./bin/server.ts",
     "dev": "tsc --noEmit && ./bin/server.ts --port 3000",
-    "start:dev": "tsc --noEmit && DEBUG=localtunnel:*,lt:ClientManager:* tsx ./bin/server.ts --domain=tunnel.toolbxapp.com --port 1234"
+    "start": "tsc --noEmit && DEBUG=* tsx ./bin/server.ts --domain=tunnel.toolbxapp.com --port 1234 --max-sockets 100"
   }
 }


### PR DESCRIPTION
### Description

Applied a few fixes for socket that gives 408 timeout:

1. Server side should send FIN/ACK when client side sends FIN

When the client side closes a socket by using `socket.end()`, the server side should also close the socket, otherwise the `socket.on('end')` event won't be triggered.

Added these lines

```
    socket.once('end', () => {
      this.debug('socket ended');
      socket.end();
    });
```

2. Server side needs to resume the socket upon receiving it.

Added `socket.resume()`, otherwise the socket on the server side won't receive any event. To receive any event, there needs to be either a `socket.on('data', () => {})` listener, or equivalently, use `socket.resume()`. Something must be reading the socket otherwise the whole stream is paused, including the end signals.

3. Use latest socket first.

New sockets are pushed into the end of the array. And when accepting requests, we should use the new sockets from the end of the array. The old sockets at the start of the array may be in the process of expiring and they just haven't triggered the 'end' event yet/

```
const sock = this.availableSockets.pop();
```

### Test plan (what/how did I test?)
Tested manually
